### PR TITLE
Add Rust file management CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ _deploy/*
 Rakefile
 .jekyll-metadata
 /.idea/
+file-manager/target/

--- a/file-manager/Cargo.toml
+++ b/file-manager/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "file-manager"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.5", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/file-manager/src/lib.rs
+++ b/file-manager/src/lib.rs
@@ -1,0 +1,31 @@
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// List paths inside a directory.
+pub fn list(path: &Path) -> io::Result<Vec<PathBuf>> {
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(path)? {
+        entries.push(entry?.path());
+    }
+    Ok(entries)
+}
+
+/// Copy file from `src` to `dest`.
+pub fn copy(src: &Path, dest: &Path) -> io::Result<u64> {
+    fs::copy(src, dest)
+}
+
+/// Move file from `src` to `dest`.
+pub fn move_file(src: &Path, dest: &Path) -> io::Result<()> {
+    fs::rename(src, dest)
+}
+
+/// Delete file or directory at `path`.
+pub fn delete(path: &Path) -> io::Result<()> {
+    if path.is_dir() {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_file(path)
+    }
+}

--- a/file-manager/src/main.rs
+++ b/file-manager/src/main.rs
@@ -1,0 +1,46 @@
+use clap::{Parser, Subcommand};
+use std::io;
+use std::path::PathBuf;
+
+use file_manager::{copy, delete, list, move_file};
+
+#[derive(Parser)]
+#[command(name = "file-manager")]
+#[command(about = "A simple file management system")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// List files in a directory
+    List { path: PathBuf },
+    /// Copy file from source to destination
+    Copy { src: PathBuf, dest: PathBuf },
+    /// Move file from source to destination
+    Move { src: PathBuf, dest: PathBuf },
+    /// Delete a file or directory
+    Delete { path: PathBuf },
+}
+
+fn main() -> io::Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::List { path } => {
+            for entry in list(&path)? {
+                println!("{}", entry.display());
+            }
+        }
+        Commands::Copy { src, dest } => {
+            copy(&src, &dest)?;
+        }
+        Commands::Move { src, dest } => {
+            move_file(&src, &dest)?;
+        }
+        Commands::Delete { path } => {
+            delete(&path)?;
+        }
+    }
+    Ok(())
+}

--- a/file-manager/tests/operations.rs
+++ b/file-manager/tests/operations.rs
@@ -1,0 +1,44 @@
+use file_manager::{copy, delete, list, move_file};
+use std::fs::File;
+use std::io::Write;
+use tempfile::tempdir;
+
+#[test]
+fn test_copy_move_delete() -> std::io::Result<()> {
+    let dir = tempdir()?;
+    let src = dir.path().join("src.txt");
+    let mut file = File::create(&src)?;
+    writeln!(file, "hello")?;
+
+    let copy_path = dir.path().join("copy.txt");
+    copy(&src, &copy_path)?;
+    assert!(copy_path.exists());
+
+    let move_path = dir.path().join("moved.txt");
+    move_file(&copy_path, &move_path)?;
+    assert!(!copy_path.exists());
+    assert!(move_path.exists());
+
+    delete(&src)?;
+    assert!(!src.exists());
+    delete(&move_path)?;
+    assert!(!move_path.exists());
+    Ok(())
+}
+
+#[test]
+fn test_list() -> std::io::Result<()> {
+    let dir = tempdir()?;
+    File::create(dir.path().join("a.txt"))?;
+    File::create(dir.path().join("b.txt"))?;
+    let mut entries = list(dir.path())?;
+    entries.sort();
+    assert_eq!(entries.len(), 2);
+    let names: Vec<_> = entries
+        .into_iter()
+        .map(|p| p.file_name().unwrap().to_owned())
+        .collect();
+    assert!(names.contains(&"a.txt".into()));
+    assert!(names.contains(&"b.txt".into()));
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add simple Rust-based file manager with list/copy/move/delete commands
- include integration tests
- ignore build artifacts

## Testing
- `cargo test` *(fails: failed to download dependencies)*
- `bundle exec jekyll build` *(fails: jekyll command not found)*
- `bundle install` *(fails: 403 Forbidden when downloading gems)*

------
https://chatgpt.com/codex/tasks/task_e_68af24e819688328aa16a6b17beff2d2